### PR TITLE
Allow use of existing secret for connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,20 @@ Clone this repository and change into its directory.
 Edit the file `values.yaml` and configure it to suit your requirements.
 In particular, edit the section `connections` to match the connection parameters and credentials for accessing your
 Synology Diskstation.
+
+You can also use an existing secret (specify using `clientInfoSecretName`) that contains the `connections` details
+under `client-info.yaml` key:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: foo-synology-csi-client-info
+data:
+  client-info.yaml: |-
+    Y2xpZW50czoKLSBob3N0OiAxOTIuMTY4LjEuMQogIGh0dHBzOiBmYWxzZQogIHBhc3N3b3JkOiBwYXNzd29yZAogIHBvcnQ6IDUwMDAKICB1c2VybmFtZTogdXNlcm5hbWUKLSBob3N0OiAxOTIuMTY4LjEuMQogIGh0dHBzOiBmYWxzZQogIHBhc3N3b3JkOiBwYXNzd29yZAogIHBvcnQ6IDUwMDEKICB1c2VybmFtZTogdXNlcm5hbWU=
+```
+
 It's a good practice to create a dedicated user for accessing the Diskstation Manager (DSM) application.
 Your user needs to be a member of the `administrator` group and have permission to access the `DSM` application.
 You can reject any other permissions.

--- a/templates/client-info.yaml
+++ b/templates/client-info.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.clientInfoSecretName }}
 ---
 apiVersion: v1
 data:
@@ -6,3 +7,4 @@ kind: Secret
 metadata:
   labels: {{- include "synology-csi.labels" $ | nindent 4 }}
   name: {{ include "synology-csi.fullname" $ }}-client-info
+{{- end }}

--- a/templates/controller.yaml
+++ b/templates/controller.yaml
@@ -167,7 +167,11 @@ spec:
       volumes:
         - name: client-info
           secret:
+            {{- if $.Values.clientInfoSecretName }}
+            secretName: {{ $.Values.clientInfoSecretName }}
+            {{- else }}
             secretName: {{ include "synology-csi.fullname" $ }}-client-info
+            {{- end }}
         - name: socket-dir
           emptyDir: { }
 {{- end }}

--- a/templates/node.yaml
+++ b/templates/node.yaml
@@ -123,7 +123,11 @@ spec:
       volumes:
         - name: client-info
           secret:
+            {{- if $.Values.clientInfoSecretName }}
+            secretName: {{ $.Values.clientInfoSecretName }}
+            {{- else }}
             secretName: {{ include "synology-csi.fullname" $ }}-client-info
+            {{- end }}
         - name: device-dir
           hostPath:
             path: /dev

--- a/templates/snapshotter.yaml
+++ b/templates/snapshotter.yaml
@@ -108,7 +108,11 @@ spec:
       volumes:
         - name: client-info
           secret:
+            {{- if $.Values.clientInfoSecretName }}
+            secretName: {{ $.Values.clientInfoSecretName }}
+            {{- else }}
             secretName: {{ include "synology-csi.fullname" $ }}-client-info
+            {{- end }}
         - name: socket-dir
           emptyDir: { }
 {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -15,6 +15,8 @@ connections:
     username: username
     password: password
 
+clientInfoSecretName:
+
 images:
   attacher:
     image: k8s.gcr.io/sig-storage/csi-attacher


### PR DESCRIPTION
If secret is created outside of this Helm chart, ensure that the user can use
it. This is useful for when the secret is created as part of some other process
(such as using a secrets manager)