### PR TITLE
Update to v1.1.3

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: v1.1.2
+appVersion: v1.1.3
 description: A Helm chart for the Synology CSI Driver
 home: https://github.com/christian-schlichtherle/synology-csi-chart
 keywords:

--- a/templates/controller.yaml
+++ b/templates/controller.yaml
@@ -93,6 +93,7 @@ spec:
             - --csi-address=$(ADDRESS)
             - --timeout=60s
             - --v=5
+            - --extra-create-metadata
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock

--- a/templates/node.yaml
+++ b/templates/node.yaml
@@ -82,7 +82,7 @@ spec:
                 fieldRef:
                   fieldPath: spec.nodeName
             - name: REGISTRATION_PATH
-              value: /var/lib/kubelet/plugins/csi.san.synology.com/csi.sock
+              value: {{ $.Values.node.kubeletPath }}/plugins/csi.san.synology.com/csi.sock
           {{- with .nodeDriverRegistrar }}
           image: {{ .image }}:{{ .tag }}
           imagePullPolicy: {{ .pullPolicy }}
@@ -122,7 +122,7 @@ spec:
             - name: host-root
               mountPath: /host
             - name: kubelet-dir
-              mountPath: /var/lib/kubelet
+              mountPath: {{ $.Values.node.kubeletPath }}
               mountPropagation: Bidirectional
             - name: plugin-dir
               mountPath: /csi
@@ -147,15 +147,15 @@ spec:
             type: Directory
         - name: kubelet-dir
           hostPath:
-            path: /var/lib/kubelet
+            path: {{ $.Values.node.kubeletPath }}
             type: Directory
         - name: plugin-dir
           hostPath:
-            path: /var/lib/kubelet/plugins/csi.san.synology.com
+            path: {{ $.Values.node.kubeletPath }}/plugins/csi.san.synology.com
             type: DirectoryOrCreate
         - name: registration-dir
           hostPath:
-            path: /var/lib/kubelet/plugins_registry
+            path: {{ $.Values.node.kubeletPath }}/plugins_registry
             type: Directory
 {{- end }}
 {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -55,6 +55,9 @@ node:
   affinity: { }
   nodeSelector: { }
   tolerations: [ ]
+  # If your kubelet path is not standard, specify it here :
+  # example for miocrok8s distrib : /var/snap/microk8s/common/var/lib/kubelet
+  kubeletPath: /var/lib/kubelet
 # Specifies affinity, nodeSelector and tolerations for the snapshotter StatefulSet
 snapshotter:
   affinity: { }


### PR DESCRIPTION
Integrates all changes that come with the release of [v1.1.3](https://github.com/SynologyOpenSource/synology-csi/releases/tag/v1.1.3) ([diff](https://github.com/SynologyOpenSource/synology-csi/compare/v1.1.2...v1.1.3)) of the synology csi controller.

@christian-schlichtherle release of chart version v1.1.3 would be greatly appreciated!
You may need to adjust the Chart Version to 0.9.8 by hand.