### PR TITLE
fix(snapshotter): allow snapshotter to PATCH VolumeSnapshotContent

### DIFF
--- a/templates/snapshotter.yaml
+++ b/templates/snapshotter.yaml
@@ -22,7 +22,7 @@ rules:
     verbs: [ "get", "list", "watch" ]
   - apiGroups: [ "snapshot.storage.k8s.io" ]
     resources: [ "volumesnapshotcontents" ]
-    verbs: [ "create", "get", "list", "watch", "update", "delete" ]
+    verbs: [ "create", "get", "list", "watch", "update", "patch", "delete" ]
   - apiGroups: [ "snapshot.storage.k8s.io" ]
     resources: [ "volumesnapshotcontents/status" ]
     verbs: [ "update" ]


### PR DESCRIPTION
I have seen the following error when describing a volumesnapshotcontent:

```
Warning  SnapshotCreationFailed  1s (x4 over 6s)  csi-snapshotter csi.san.synology.com  Failed to create snapshot: failed to add VolumeSnapshotBeingCreated annotation on the content snapcontent-1b86453a-7fa5-4599-a6f5-fe47bb6cc83d: "snapsh
ot controller failed to update snapcontent-1b86453a-7fa5-4599-a6f5-fe47bb6cc83d on API server: volumesnapshotcontents.snapshot.storage.k8s.io \"snapcontent-1b86453a-7fa5-4599-a6f5-fe47bb6cc83d\" is forbidden: User \"system:serviceaccount:syn
ology-csi:synology-csi-snapshotter\" cannot patch resource \"volumesnapshotcontents\" in API group \"snapshot.storage.k8s.io\" at the cluster scope" 
```

This change fixes it.
