### PR TITLE
Add configuration and settings to resolve issues installing on Talos

### DIFF
--- a/templates/configmap.yaml
+++ b/templates/configmap.yaml
@@ -1,0 +1,21 @@
+{{- if (default false .Values.talos) }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "synology-csi.fullname" $ }}-chroot-configmap
+  namespace: {{ .Release.Namespace }}
+data:
+  chroot.sh: |
+    #!/usr/bin/env bash
+    DIR="/host" # csi-node mount / of the node to /host in the container
+    BIN="$(basename "$0")"
+
+    iscsid_pid=$(pgrep iscsid)
+
+    echo "$@"
+
+    if [ -d "$DIR" ]; then
+        echo "entering nsenter"
+        nsenter --mount="/proc/${iscsid_pid}/ns/mnt" --net="/proc/${iscsid_pid}/ns/net" -- "/usr/local/sbin/$BIN" "$@"
+    fi
+{{- end }}

--- a/templates/node.yaml
+++ b/templates/node.yaml
@@ -1,3 +1,4 @@
+{{- $talosEnabled := (default false .Values.talos) -}}
 {{- with $.Values }}
 ---
 apiVersion: v1
@@ -67,6 +68,9 @@ spec:
       {{- with .affinity }}
       affinity: {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{ if $talosEnabled }}
+      hostPID: true
+      {{- end }}
       containers:
         - name: csi-driver-registrar
           args:
@@ -126,6 +130,11 @@ spec:
               mountPropagation: Bidirectional
             - name: plugin-dir
               mountPath: /csi
+            {{- if $talosEnabled }}
+            - name: chroot-script
+              mountPath: /csibin/chroot.sh
+              subPath: chroot.sh
+            {{- end }}
       hostNetwork: true
       {{- with .nodeSelector }}
       nodeSelector: {{- toYaml . | nindent 8 }}
@@ -152,5 +161,14 @@ spec:
           hostPath:
             path: {{ .kubeletPath }}/plugins/csi.san.synology.com
             type: DirectoryOrCreate
+        {{- if $talosEnabled }}
+        - name: chroot-script
+          configMap:
+            name: {{ include "synology-csi.fullname" $ }}-chroot-configmap
+            defaultMode: 0777
+            items:
+              - key: chroot.sh
+                path: chroot.sh
+        {{- end }}
 {{- end }}
 {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -49,6 +49,9 @@ images:
     pullPolicy: IfNotPresent
     tag: v6.2.2
 installCSIDriver: true
+# If using Talos.dev set to true to 
+# create a ConfigMap with a chroot script override and set hostPID to true for the node DaemonSet
+talos: false
 nameOverride: ""
 # Specifies affinity, nodeSelector and tolerations for the node DaemonSet
 node:


### PR DESCRIPTION
Updated the chart to resolve issues installing into Talos as per instructions found at [https://github.com/mlbiam/Kargo/blob/main/ISCSI.md](https://github.com/mlbiam/Kargo/blob/main/ISCSI.md)

Tested locally without overrides and the template created matches the original.
With .Values.talos set to true installs and works under Talos as long as the iscsi-tools extension has been added.