### PR TITLE
Added patch permissions for volumesnapshotcontents/status

### DIFF
--- a/templates/snapshotter.yaml
+++ b/templates/snapshotter.yaml
@@ -25,7 +25,7 @@ rules:
     verbs: [ "create", "get", "list", "watch", "update", "patch", "delete" ]
   - apiGroups: [ "snapshot.storage.k8s.io" ]
     resources: [ "volumesnapshotcontents/status" ]
-    verbs: [ "update" ]
+    verbs: [ "update", "patch" ]
 
 ---
 kind: ClusterRoleBinding


### PR DESCRIPTION
First of all, thank you very much for this helm chart!

I've ran into RBAC issues when taking a snapshot, so I ended up adding these extra permissions to make it work:
https://github.com/mmontes11/k8s-infrastructure/blob/a4347163f5abdd3aef7e7deb9f1c96396937b13f/infrastructure/synology-csi/helmrelease.yaml#L100

The snapshot controller is unable to mark the `VolumeSnapshotContent` as ready due to lack of permissions. Latest versions of the external-snapshotter require `patch` permissions for this:
https://github.com/kubernetes-csi/external-snapshotter/blob/master/deploy/kubernetes/snapshot-controller/rbac-snapshot-controller.yaml#L54

This PR adds the required patch permissions.
