### PR TITLE
Publish helm artifacts as OCI package

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,10 +8,17 @@ jobs:
       GITHUB_REPOSITORY_NAME: ${{ github.event.repository.name }}
     permissions:
       contents: write
+      packages: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4 # https://github.com/actions/checkout
       - uses: azure/setup-helm@v4 # https://github.com/azure/setup-helm
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Package and index Helm chart
         run: make dist
       - uses: peaceiris/actions-gh-pages@v4 # https://github.com/peaceiris/actions-gh-pages

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ dist:
 	helm package . --destination dist
 	curl --fail --output-dir dist --remote-name --silent $(REPO_URL)/index.yaml || true
 	helm repo index dist --merge dist/index.yaml --url $(REPO_URL)
+	helm push ./dist/*.tgz oci://ghcr.io/$(GITHUB_REPOSITORY)
 
 .PHONY: template
 template: custom.yaml


### PR DESCRIPTION
Updates the `make dist` job to also publish the helm charts as an OCI artifact to ghcr.io

Closes #25 